### PR TITLE
Add dockerfile and accompanying docs

### DIFF
--- a/norbit-webapp/Dockerfile
+++ b/norbit-webapp/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-bullseye
+# Valid values: prod, dev
+ARG BUILD_MODE=prod
+
+WORKDIR /app/
+
+# Cache dependency layer
+COPY package.json package-lock.json /app
+RUN npm install
+
+# Copy the entire working directory
+COPY . /app/
+ENV BUILD_MODE=$BUILD_MODE
+
+EXPOSE 3000
+
+CMD ["/app/scripts/docker_run.sh"]

--- a/norbit-webapp/README.md
+++ b/norbit-webapp/README.md
@@ -32,3 +32,25 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Using the Dockerfile
+
+The dockerfile creates a standard environment for running the app. The dockerfile is based on Debian with Node.js 20, using the official Node.js image.
+
+There are two different modes, which is specified at image build time. By default, the image is built in production mode, meaning it runs `npm run build && npm run start`. The image can be built in development mode instead, which runs `npm run dev` instead.
+
+Example commands:
+```
+cd norbit-webapp
+# Option 1: dev mode
+docker build --build-arg BUILD_MODE=dev -t norbit .
+# Option 2: production mode
+docker build -t norbit . 
+
+docker run -p 3000:3000 --rm -ti norbit
+```
+(the exact name is not important; you can pick a different name, particularly if you're running both debug and production containers on the same system)
+
+Note that in neither case does it sync the source tree into the docker container. Due to limitations of how volumes are mounted, filesystem update information [is discarded][docker-volume-info-discard], meaning `npm run dev` doesn't pick up file changes. Using the dockerfile for development therefore requires a rebuild of the dockerfile for all changes. It's recommended to create a copyable command for reuse for development instead, or running locally.
+
+[docker-volume-info-discard]: https://forums.docker.com/t/docker-compose-not-synchronising-file-changes-in-volume/79177/4

--- a/norbit-webapp/scripts/docker_run.sh
+++ b/norbit-webapp/scripts/docker_run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "${BUILD_MODE}" == "prod" ];
+then
+    npm run build && npm run start
+else
+    npm run dev
+fi
+
+# vim:ff=unix


### PR DESCRIPTION
Closes #15

For reasons outlined in norbit-webapp/README.md, the Dockerfile doesn't sync to filesystem changes, because both forms of host volume mounting discards the file update information `npm run dev` relies on to detect changes.