### PR TITLE
Set up integration tests for the data in all charts

### DIFF
--- a/norbit-webapp/README.md
+++ b/norbit-webapp/README.md
@@ -84,6 +84,18 @@ Component tests are comparatively self-contained; Cypress spawns a dummy server 
 
 Note: the integration tests require the server to run separately. You can run it with `npm run build && npm run start`, or `npm run dev` in a separate terminal tab prior to running the tests. As long as the server is on port `:3000`, Cypress will connect and run.
 
-When the server is up, you can use `npm run integration-test` to run the tests.
+**Note:** For the integration tests to run properly, it's required to set `NEXT_PUBLIC_MOCK_AMPLIFY=yes` before running `npm run dev` (or equivalent). This disables the live Amplify connection. If you're using a Unix-style terminal (bash, zsh, fish, etc.), you can do this by running `NEXT_PUBLIC_MOCK_AMPLIFY=yes npm run dev`. 
+
+Alternatively, before running the server commands, you can run...:
+
+* Unix-style shells (Linux and Mac shells, as well as Git Bash and Cygwin): `export NEXT_PUBLIC_MOCK_AMPLIFY=yes`
+* Powershell: `$Env:NEXT_PUBLIC_MOCK_AMPLIFY = 'yes'`
+* Cmd: `set NEXT_PUBLIC_MOCK_AMPLIFY=yes`
+
+Note that these options requires the variable to be unset (or set to a different value than yes) if you want to re-enable Amplify. Alternatively, you can open a new terminal session, which also wipes the variables.
+
+---
+
+When the server is up, you can use `npm run integration-test` to run the tests. Note that if Amplify hasn't been mocked before running the server, certain tests may occasionally fail (see [#67](https://github.com/simeeid/TDT4290Group1/pull/67), where the tests worked locally, but failed in the CI because of the amplify connection, for reasons still unknown), while others designed for this variable to be set (such as the graph data tests) may fail outright.
 
 As long as the server is running, to run all tests at once, you can use `npm run unit-test && npm run component-test && npm run integration-test` to run all the tests in a single command.

--- a/norbit-webapp/components/ChartComponent/ChartComponent.tsx
+++ b/norbit-webapp/components/ChartComponent/ChartComponent.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { ChartData, ChartProps } from './types';
-import { LineChart, Line, XAxis, YAxis, Tooltip, Label } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, Tooltip, Label, Dot, DotProps } from 'recharts';
 
 export const ChartComponent: React.FC<ChartProps> = ({ data, chartLabel, paddingOffset, onPauseStateChange }) => {
   const offset = paddingOffset == null ? 1 : paddingOffset;
@@ -34,7 +34,12 @@ export const ChartComponent: React.FC<ChartProps> = ({ data, chartLabel, padding
         data={isPaused ? pauseBuffer : data}
         margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
       >
-        <Line type="monotone" dataKey="datapoint" isAnimationActive={false} stroke="#8884d8" />
+        <Line
+          type="monotone"
+          dataKey="datapoint"
+          isAnimationActive={false}
+          stroke="#8884d8"
+        />
         <XAxis dataKey="timestamp" />
         <YAxis domain={[minValue - offset, maxValue + offset]}>
           {chartLabel ? <Label angle={-90} value={chartLabel} position="insideLeft" style={{textAnchor: 'middle'}} /> : ""}

--- a/norbit-webapp/components/ChartComponent/ChartComponent.tsx
+++ b/norbit-webapp/components/ChartComponent/ChartComponent.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { ChartData, ChartProps } from './types';
-import { LineChart, Line, XAxis, YAxis, Tooltip, Label, Dot, DotProps } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, Tooltip, Label } from 'recharts';
 
 export const ChartComponent: React.FC<ChartProps> = ({ data, chartLabel, paddingOffset, onPauseStateChange }) => {
   const offset = paddingOffset == null ? 1 : paddingOffset;

--- a/norbit-webapp/components/LightIntensityComponent/LightIntensityComponent.tsx
+++ b/norbit-webapp/components/LightIntensityComponent/LightIntensityComponent.tsx
@@ -4,6 +4,7 @@ import { ChartData } from '../ChartComponent/types';
 import { TamplifyInstance } from '@/dashboard/Dashboard';
 import { useSubscribeToTopics } from 'utils/useSubscribeToTopic';
 import { TLightIntensityData } from './types';
+import {MockInputComponent} from '@/MockInputComponent/MockInputComponent';
 
 export const LightIntensityComponent: React.FC<{ amplifyInstance: TamplifyInstance | null }> = ({ amplifyInstance }) => {
   const [data, setData] = useState<ChartData[]>([]);
@@ -66,13 +67,14 @@ export const LightIntensityComponent: React.FC<{ amplifyInstance: TamplifyInstan
   useSubscribeToTopics('lux/topic', amplifyInstance, setLightIntensityData);
 
   return (
-      <div className="sensorContainer">
-          <h2>Light Intensity</h2>
-          <ChartComponent
-              data={data}
-              onPauseStateChange={onPauseStateChange}
-              chartLabel="Light Intensity"
-          />
+      <div className="sensorContainer" id="light-container">
+        <h2>Light Intensity</h2>
+        <ChartComponent
+            data={data}
+            onPauseStateChange={onPauseStateChange}
+            chartLabel="Light Intensity"
+        />
+        { amplifyInstance == null && <MockInputComponent data={data} setData={setData} /> }
       </div>
   );
 }

--- a/norbit-webapp/components/MockInputComponent/MockInputComponent.tsx
+++ b/norbit-webapp/components/MockInputComponent/MockInputComponent.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {MockInputProps} from "./types";
+
+/**
+ * This component deals with mocking input in integration tests, as there's no trivial way to mock
+ * the Amplify connection within them due to the server being run separately. 
+ * This provides a hidden input field (when enabled; this should not be present unless
+ * it's determined that amplify is in a mocked state) that tests can use to sneak in data.
+ * This is not _really_ in the spirit of integration testing, but mocking amplify is far
+ * too complex for me to do, and involves using a command line utility I don't have access to.
+ *
+ * Using component tests to fill the gap (which are mockable and much more controllable)
+ * should allow for the entire system to be tested regardless.
+ */
+export const MockInputComponent: React.FC<MockInputProps> = ({data, setData}) => {
+  const updateData = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+
+    ev.preventDefault();
+    if (ev.key != "Enter") {
+      return;
+    }
+    
+    const elem = ev.currentTarget as HTMLInputElement;
+    let newData = elem.value;
+    if (newData != null && newData.length != 0) {
+      // Not all the data is floats, but it's easier to work with.
+      let num = parseFloat(newData);
+
+      let dataEntry = {
+        timestamp: (data.length + 1).toString(),
+        datapoint: num
+      };
+
+      setData([...data, dataEntry]);
+    }
+
+    // Wipe the input field
+    elem.value = "";
+  };
+
+  return (
+    <input type="number" style={{display: 'none'}} onKeyUp={updateData}/>
+  );
+};

--- a/norbit-webapp/components/MockInputComponent/MockInputComponent.tsx
+++ b/norbit-webapp/components/MockInputComponent/MockInputComponent.tsx
@@ -16,6 +16,12 @@ export const MockInputComponent: React.FC<MockInputProps> = ({data, setData}) =>
   const updateData = (ev: React.KeyboardEvent<HTMLInputElement>) => {
 
     ev.preventDefault();
+    // This is a hack, because onChange (in react, a demo I found elsewhere required enter)
+    // is called on every change, and not just when the user has stopped typing (i.e. a change
+    // in onChange is the smallest atom for change, and not what the user might consider a 
+    // change).
+    //
+    // This function waits for the enter key to be pressed, and only then does it submit the result.
     if (ev.key != "Enter") {
       return;
     }
@@ -34,7 +40,7 @@ export const MockInputComponent: React.FC<MockInputProps> = ({data, setData}) =>
       setData([...data, dataEntry]);
     }
 
-    // Wipe the input field
+    // Wipe the input field. This saves time during testing
     elem.value = "";
   };
 

--- a/norbit-webapp/components/MockInputComponent/types.tsx
+++ b/norbit-webapp/components/MockInputComponent/types.tsx
@@ -1,0 +1,6 @@
+import {ChartData} from "@/ChartComponent/types";
+
+export interface MockInputProps {
+  data: ChartData[];
+  setData: (data: ChartData[]) => void; 
+};

--- a/norbit-webapp/components/SoundLevelComponent/SoundLevelComponent.tsx
+++ b/norbit-webapp/components/SoundLevelComponent/SoundLevelComponent.tsx
@@ -4,13 +4,14 @@ import { ChartData } from '../ChartComponent/types';
 import { TamplifyInstance } from '@/dashboard/Dashboard';
 import { useSubscribeToTopics } from 'utils/useSubscribeToTopic';
 import { TSoundLevelData } from './types';
+import {MockInputComponent} from '@/MockInputComponent/MockInputComponent';
 
 export const SoundLevelComponent: React.FC<{amplifyInstance: TamplifyInstance | null}> = ({amplifyInstance}) => {
   const [data, setData] = useState<ChartData[]>([]);
   const [buffer, setBuffer] = useState<ChartData[]>([]);
   const [isPaused, setIsPaused] = useState(false);
   const [soundLevelData, setSoundLevelData] = useState<TSoundLevelData | null>(null);
-  console.log(soundLevelData);
+  //console.log(soundLevelData);
 
   const onPauseStateChange = (newState: boolean) => {
     setIsPaused(newState);
@@ -24,6 +25,7 @@ export const SoundLevelComponent: React.FC<{amplifyInstance: TamplifyInstance | 
   };
 
   useEffect(() => {
+    
     if (soundLevelData) {
       const newData = transformToChartData(soundLevelData);
 
@@ -64,13 +66,14 @@ export const SoundLevelComponent: React.FC<{amplifyInstance: TamplifyInstance | 
   useSubscribeToTopics('noise/topic', amplifyInstance, setSoundLevelData);
 
   return (
-    <div className="sensorContainer">
+    <div className="sensorContainer" id="sound-container">
       <h2>Sound Level</h2>
       <ChartComponent
         data={data}
         onPauseStateChange={onPauseStateChange}
         chartLabel="Sound Level (dB)"
       />
+      { amplifyInstance == null && <MockInputComponent data={data} setData={setData} /> }
     </div>
   );
 }

--- a/norbit-webapp/components/TemperatureComponent/TemperatureComponent.tsx
+++ b/norbit-webapp/components/TemperatureComponent/TemperatureComponent.tsx
@@ -4,6 +4,7 @@ import { ChartComponent } from '../ChartComponent/ChartComponent';
 import { ChartData } from '../ChartComponent/types';
 import { TamplifyInstance } from '@/dashboard/Dashboard';
 import { useSubscribeToTopics } from 'utils/useSubscribeToTopic';
+import {MockInputComponent} from '@/MockInputComponent/MockInputComponent';
 
 export const TemperatureComponent: React.FC<{amplifyInstance: TamplifyInstance | null}> = ({amplifyInstance}) => {
   const [data, setData] = useState<ChartData[]>([]);
@@ -52,13 +53,14 @@ export const TemperatureComponent: React.FC<{amplifyInstance: TamplifyInstance |
   useSubscribeToTopics('temperature/topic', amplifyInstance, setTemperatureData);
 
   return (
-    <div className="sensorContainer">
+    <div className="sensorContainer" id="temperature-container">
       <h2>Temperature</h2>
       <ChartComponent
         data={data}
         onPauseStateChange={onPauseStateChange}
         chartLabel="Temperature"
       />
+      { amplifyInstance == null && <MockInputComponent data={data} setData={setData} /> }
     </div>
   );
 }

--- a/norbit-webapp/components/accelerometer/AccelerometerChart.tsx
+++ b/norbit-webapp/components/accelerometer/AccelerometerChart.tsx
@@ -4,6 +4,7 @@ import { ChartData } from '../ChartComponent/types';
 import { TamplifyInstance } from '@/dashboard/Dashboard';
 import { useSubscribeToTopics } from 'utils/useSubscribeToTopic';
 import { TAccelerometerData } from './types';
+import {MockInputComponent} from '@/MockInputComponent/MockInputComponent';
 
 const AccelerometerChart: React.FC<{amplifyInstance: TamplifyInstance | null}> = ({amplifyInstance}) => {
   const [data, setData] = useState<ChartData[]>([]);
@@ -63,13 +64,14 @@ const AccelerometerChart: React.FC<{amplifyInstance: TamplifyInstance | null}> =
   useSubscribeToTopics('accelerometer/topic', amplifyInstance, setAccelerometerData);
 
   return (
-    <div className="sensorContainer">
+    <div className="sensorContainer" id="acceleration-container">
       <h2>Acceleration</h2>
       <ChartComponent
         data={data}
         onPauseStateChange={onPauseStateChange}
         chartLabel="Acceleration"
       />
+      { amplifyInstance == null && <MockInputComponent data={data} setData={setData} /> }
     </div>
   );
 }

--- a/norbit-webapp/pages/index.tsx
+++ b/norbit-webapp/pages/index.tsx
@@ -2,8 +2,6 @@ import Head from 'next/head'
 import styles from '@styles/Home.module.css'
 import Dashboard from 'components/dashboard/Dashboard'
 
-import { useEffect, useState } from 'react';
-
 export default function Home() {
   
   return (

--- a/norbit-webapp/tests/cypress/integration/GraphDataTests.cy.tsx
+++ b/norbit-webapp/tests/cypress/integration/GraphDataTests.cy.tsx
@@ -22,7 +22,7 @@ describe("Numeric graphs", () => {
   // Note: if this test fails, you've failed to, or incorrectly set, the
   // NEXT_PUBLIC_MOCK_AMPLIFY variable to "yes" before running the server.
   // See norbit-webapp/README.md for more information. Failure to set this variable
-  // will result in many integraion tests being flaky, or outright failing to run.
+  // will result in many integration tests being flaky, or outright failing to run.
   it("should contain, but not show the hidden mock input element", () => {
     for (const id of graphIds) {
       const htmlId = "#" + id;

--- a/norbit-webapp/tests/cypress/integration/GraphDataTests.cy.tsx
+++ b/norbit-webapp/tests/cypress/integration/GraphDataTests.cy.tsx
@@ -1,0 +1,95 @@
+describe("Numeric graphs", () => {
+  let graphIds = [
+    "acceleration-container",
+    // Temperature chart tests are disabled for now, due to it still using dummy data
+    //"temperature-container",
+    "sound-container",
+    "light-container",
+  ];
+
+  const insertMockData = (id: string, data: number) => {
+    cy.get(id + " > input")
+      .first()
+      .should("exist")
+      // force: true is required, as the field is invisible (which itself is a nasty hack)
+      .type(data + "{enter}", {force: true});
+  };
+
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+  // Note: if this test fails, you've failed to, or incorrectly set, the
+  // NEXT_PUBLIC_MOCK_AMPLIFY variable to "yes" before running the server.
+  // See norbit-webapp/README.md for more information. Failure to set this variable
+  // will result in many integraion tests being flaky, or outright failing to run.
+  it("should contain, but not show the hidden mock input element", () => {
+    for (const id of graphIds) {
+      const htmlId = "#" + id;
+      cy.get(htmlId)
+        .should("exist");
+      cy.get(htmlId + " > input")
+        .first()
+        .should("exist")
+        .and("not.be.visible");
+    }
+  });
+  it("should render the graph on the page", () => {
+    for (const id of graphIds) {
+      const htmlId = "#" + id;
+      cy.get(htmlId)
+        .should("exist");
+      cy.get(htmlId)
+        .find(".recharts-wrapper")
+        .should("exist")
+        .and("be.visible");
+    }
+  });
+  it("should render the data", () => {
+    // Insert data
+    let dataStart = 0;
+    for (const id of graphIds) {
+      const htmlId = "#" + id;
+      for (let i = 0; i < 5; ++i) {
+        insertMockData(htmlId, dataStart);
+        ++dataStart;
+      }
+    }
+
+    cy.wait(300);
+
+    let chartIdx = 0;
+    for (const id of graphIds) {
+      const htmlId = "#" + id;
+      // Assert the size is as expected
+      cy.get(htmlId + " .recharts-line-dots")
+        .children()
+        .should("have.length", 5);
+      // The index represents the data ID, as the label is used is just the length of the data
+      // at the time of insertion.
+      for (let i = 0; i < 5; ++i) {
+        // Compute the value of this point. Eachc chart tested is guaranteed to have 5 data points,
+        // and the datapoint increment does not reset per component. This is to ensure there isn't
+        // some weird, unexpected entanglement between the graphs (i.e. to ensure the output of
+        // one graph doesn't depend on the output of another)
+        let datapoint = 5 * chartIdx + i;
+
+        cy.get(htmlId + " .recharts-line-dots")
+          .children()
+          .eq(i)
+          .trigger("mousemove", {force: true})
+          .wait(200);
+
+        cy.get(htmlId + " .recharts-tooltip-label")
+          .should("have.text", `${i + 1}`);
+        cy.get(htmlId + " .recharts-tooltip-item-value")
+          .should("have.text", `${datapoint}`);
+
+      }
+
+      ++chartIdx;
+    }
+  });
+});
+
+export {};


### PR DESCRIPTION
Except for TemperatureChart, as it still uses dummy data, meaning the tests cannot be done. The tests rely on the current amplify mocking system, as amplify is incredibly difficult to test without using proper mocking (like what's possible in component- and unit tests).

The tests consist of a few steps: the first validates that the mocking system is in place (as it requires manual, server-sided configuration, because Cypress). After that, it validates the existence of the charts. Finally, it inputs data, and validates that the rendered data is the expected data by using the labels. Recharts does not store raw data directly in the HTML for some reason, which means labels is the easiest way to test that the charts display the expected data.

For now, the data provided is consistent dummy data, and that's generated to ensure no point has a unique value (though the timestamps are fixed, the values are not). This is done to ensure the overall graph rendering doesn't rely on some shared state that makes several graphs render the same content when that's undesirable. 

Closes #44, though this framework does not extend to the upcoming geolocation component. Testing that will likely require more creative mocking, or maybe using component tests and proper mocking.