### PR TITLE
Move SensorConfig struct into redux, move sensor config display to sidebar

### DIFF
--- a/norbit-webapp/components/SidebarComponent/SidebarComponent.tsx
+++ b/norbit-webapp/components/SidebarComponent/SidebarComponent.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import { SidebarProps } from './types'
 import {useAppDispatch, useAppSelector} from '@redux/hook';
 import { deviceList, push } from '@redux/slices/DeviceList';
+import SensorConfigurationPanel from '@/sensorConfiguration/SensorConfigurationPanel';
 
 export const SidebarComponent: React.FC<SidebarProps> = ({}) => {
   let dispatch = useAppDispatch();
@@ -88,13 +89,16 @@ export const SidebarComponent: React.FC<SidebarProps> = ({}) => {
             <label htmlFor="device-id">Enter device ID</label>
             <input id="device-id" name="device-id" placeholder="ABCD1234"  />
 
-            <button id="submit-device-id" className="dark" type="submit">Connect now!</button>
+            <button id="submit-device-id" className="green" type="submit">Connect now!</button>
           </form>
 
           <hr />
           <h2>Device list</h2>
 
           { deviceHtml.length == 0 ? <p>No devices connected :(</p> : <div className="device-list">{deviceHtml}</div> }
+        </div>
+        <div className="configurationPanel">
+          <SensorConfigurationPanel />
         </div>
 
       </div>

--- a/norbit-webapp/components/SidebarComponent/SidebarComponent.tsx
+++ b/norbit-webapp/components/SidebarComponent/SidebarComponent.tsx
@@ -3,8 +3,8 @@ import { connectDevice, Device } from '@/DeviceManager';
 import React, { useState } from 'react';
 
 import { SidebarProps } from './types'
-import {useAppDispatch, useAppSelector} from '@redux/hook';
-import { deviceList, push } from '@redux/slices/DeviceList';
+import { useAppDispatch, useAppSelector } from '@redux/hook';
+import { push } from '@redux/slices/DeviceList';
 import SensorConfigurationPanel from '@/sensorConfiguration/SensorConfigurationPanel';
 
 export const SidebarComponent: React.FC<SidebarProps> = ({}) => {
@@ -78,11 +78,6 @@ export const SidebarComponent: React.FC<SidebarProps> = ({}) => {
                     idField.value = "";
                   }
               
-                  // This is a disgusting hack
-                  //setSidebarActive(false);
-                  //setTimeout(() => {
-                    //setSidebarActive(true);
-                  //}, 0);
                 });
             }
           }}>

--- a/norbit-webapp/components/dashboard/Dashboard.module.css
+++ b/norbit-webapp/components/dashboard/Dashboard.module.css
@@ -20,8 +20,3 @@
     border-radius: 5px;
   }
 
-.configurationPanel {
-  flex: 1;
-  border-left: 1px solid #ddd;
-}
-

--- a/norbit-webapp/components/dashboard/Dashboard.tsx
+++ b/norbit-webapp/components/dashboard/Dashboard.tsx
@@ -1,21 +1,18 @@
-import React, { useState } from 'react';
+import React from 'react';
 import AccelerometerChart from '../accelerometer/AccelerometerChart';
-import SensorConfigurationPanel from '../sensorConfiguration/SensorConfigurationPanel';
 import dashboardStyles from './Dashboard.module.css';
-import { SensorConfig } from '../sensorConfiguration/types';
-import {TemperatureComponent} from '../TemperatureComponent/TemperatureComponent';
-import {SoundLevelComponent} from '../SoundLevelComponent/SoundLevelComponent';
-import {LightIntensityComponent} from '../LightIntensityComponent/LightIntensityComponent';
+import { TemperatureComponent } from '../TemperatureComponent/TemperatureComponent';
+import { SoundLevelComponent } from '../SoundLevelComponent/SoundLevelComponent';
+import { LightIntensityComponent } from '../LightIntensityComponent/LightIntensityComponent';
 import { Amplify } from 'aws-amplify';
 
 import { AWSIoTProvider } from '@aws-amplify/pubsub/lib/Providers';
+import { useAppSelector } from '@redux/hook';
 
 export type TamplifyInstance = typeof Amplify;
 
 const Dashboard: React.FC = () => {
-  
-  const [sensorConfig, setSensorConfig] = useState<SensorConfig>({ accelerometer: true, temperature: true, light: true, sound: true });
-
+  let sensorConfig = useAppSelector((state) => state.sensorConfig);
 
   const config = {
     identityPoolId: process.env.NEXT_PUBLIC_IDENTITY_POOL_ID,
@@ -46,9 +43,6 @@ const Dashboard: React.FC = () => {
         {sensorConfig.temperature && <TemperatureComponent amplifyInstance={mockAmplify ? Amplify : null} />}
         {sensorConfig.light && <LightIntensityComponent amplifyInstance={mockAmplify ? Amplify : null} />}
         {sensorConfig.sound && <SoundLevelComponent amplifyInstance={mockAmplify ? Amplify : null} />}
-      </div>
-      <div className={dashboardStyles.configurationPanel}>
-        <SensorConfigurationPanel onConfigurationChange={setSensorConfig} />
       </div>
     </div>
   );

--- a/norbit-webapp/components/sensorConfiguration/SensorConfigurationPanel.module.css
+++ b/norbit-webapp/components/sensorConfiguration/SensorConfigurationPanel.module.css
@@ -14,7 +14,7 @@
 }
 
 .configGroup {
-  border-bottom: 2px solid #F4F2F0;
+  /*border-bottom: 2px solid #F4F2F0;*/
   width: 100%;
   padding: 4px;
 }

--- a/norbit-webapp/components/sensorConfiguration/SensorConfigurationPanel.tsx
+++ b/norbit-webapp/components/sensorConfiguration/SensorConfigurationPanel.tsx
@@ -1,28 +1,36 @@
 'use client'
 
-import React, { useState } from 'react';
+import {useAppDispatch, useAppSelector} from '@redux/hook';
+import {SensorConfig, setState} from '@redux/slices/SensorConfig';
+import React from 'react';
 import style from './SensorConfigurationPanel.module.css';
-import { SensorConfig, Props } from './types'; 
 
-
-const SensorConfigurationPanel: React.FC<Props> = ({ onConfigurationChange }) => {
-  const [config, setConfig] = useState<SensorConfig>({ accelerometer: true, temperature: true, sound: true, light: true });
+const SensorConfigurationPanel: React.FC = () => {
+  //const [config, setConfig] = useState<SensorConfig>({ accelerometer: true, temperature: true, sound: true, light: true });
+  let dispatch = useAppDispatch();
+  let config = useAppSelector((state) => state.sensorConfig);
 
   const handleToggle = (sensor: keyof SensorConfig) => {
-    const newConfig = {
-      ...config,
-      [sensor]: !config[sensor],
-    };
-    setConfig(newConfig);
-    onConfigurationChange(newConfig);
+    dispatch(
+      setState({
+        newValue: !config[sensor], 
+        field: sensor
+      })
+    );
   };
 
   return (
     <div className= {style.labelBlock} id="sensor-panel">
       <h3>Sensor Configuration</h3>
+      {/*
+        Note that these blocks are excessively verbose to better accomodate future changes,
+        particularly by enabling sane groupings if sensors suddenly get more config (such as
+        sampling rate).
+
+        I.e. it's an intentional choice for maintainability
+      */}
       <div className={style.configRoot} id="config-root">
         <div className={style.configGroup}>
-          <h4>Accelerometer settings</h4>
           <div className={style.optionGroup}>
             <input
               id="enable-accelerometer"
@@ -35,7 +43,6 @@ const SensorConfigurationPanel: React.FC<Props> = ({ onConfigurationChange }) =>
         </div>
 
         <div className={style.configGroup}>
-          <h4>Temperature settings</h4>
           <div className={style.optionGroup}>
             <input 
               id="enable-temperature"
@@ -48,7 +55,6 @@ const SensorConfigurationPanel: React.FC<Props> = ({ onConfigurationChange }) =>
         </div>
 
         <div className={style.configGroup}>
-          <h4>Light intensity settings</h4>
           <div className={style.optionGroup}>
             <input 
               id="enable-light"
@@ -61,7 +67,6 @@ const SensorConfigurationPanel: React.FC<Props> = ({ onConfigurationChange }) =>
         </div>
 
         <div className={style.configGroup}>
-          <h4>Sound level settings</h4>
           <div className={style.optionGroup}>
             <input 
               id="enable-sound"

--- a/norbit-webapp/components/sensorConfiguration/types.ts
+++ b/norbit-webapp/components/sensorConfiguration/types.ts
@@ -1,11 +1,6 @@
-export interface SensorConfig {
-  accelerometer: boolean;
-  temperature: boolean;
-  light: boolean;
-  sound: boolean;
-  // Other sensors can be added here, e.g., temperature: boolean;
-}
+import {SensorConfig} from "@redux/slices/SensorConfig";
 
 export interface Props {
   onConfigurationChange: (config: SensorConfig) => void;
+  config: SensorConfig;
 }

--- a/norbit-webapp/redux/slices/SensorConfig.tsx
+++ b/norbit-webapp/redux/slices/SensorConfig.tsx
@@ -1,0 +1,30 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit"
+
+export interface SensorConfig {
+  accelerometer: boolean;
+  temperature: boolean;
+  light: boolean;
+  sound: boolean;
+  // Other sensors can be added here, e.g., temperature: boolean;
+}
+
+export const sensorConfig = createSlice({
+  name: "sensorConfig",
+  initialState: {
+    accelerometer: true,
+    temperature: false,
+    light: true,
+    sound: true,
+  },
+  reducers: {
+    setState: (state, payload: PayloadAction<
+                  {newValue: boolean, field: keyof SensorConfig}
+    >) => {
+      state[payload.payload.field] = payload.payload.newValue;
+    }
+  }
+});
+
+export const { setState } = sensorConfig.actions;
+
+export default sensorConfig.reducer;

--- a/norbit-webapp/redux/store.tsx
+++ b/norbit-webapp/redux/store.tsx
@@ -1,9 +1,11 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { deviceList } from "./slices/DeviceList";
+import {sensorConfig} from "./slices/SensorConfig";
 
 export const store = configureStore({
   reducer: {
     deviceList: deviceList.reducer,
+    sensorConfig: sensorConfig.reducer,
   },
   devTools: process.env.NODE_ENV !== "production",
 });

--- a/norbit-webapp/styles/SidebarComponent.css
+++ b/norbit-webapp/styles/SidebarComponent.css
@@ -36,12 +36,13 @@
   z-index: 9001;
   position: fixed;
   width: 30%;
-  height: 100%;
+  height: 100vh;
   top: 0;
   left: calc(100% - 30%);
   background: #02222F;
   padding: 8px;
   box-sizing: border-box;
+  overflow-y: scroll;
 
   transition: all 1s ease-in;
   color: white;

--- a/norbit-webapp/styles/globals.css
+++ b/norbit-webapp/styles/globals.css
@@ -31,6 +31,11 @@ html {
   text-align: center;
 }
 
+button {
+  border-radius: 12px;
+  cursor: pointer;
+}
+
 button.light {
   background-color: var(--color-primary);
   color: white;
@@ -47,4 +52,14 @@ button.dark {
   border-radius: 5px;
   padding: 5px 10px;
   box-sizing: border-box;
+}
+
+button.green {
+  background-color: #22c632;
+  border: 2px solid #1d9c29;
+  color: black;
+}
+button.green:hover {
+  background-color: #1d9c29;
+  color: black;
 }

--- a/norbit-webapp/tests/cypress/component/HeaderTests.cy.tsx
+++ b/norbit-webapp/tests/cypress/component/HeaderTests.cy.tsx
@@ -22,6 +22,43 @@ describe('Header', () => {
     cy.get("button.hamburger-button").click();
     cy.get("div.sidebar").should("be.visible");
   });
+  it("Should contain sensor config", () => {
+    cy.mount(<HeaderComponent useSidebar={true} />);
+    cy.get("div.sidebar").should("not.be.visible");
+    cy.get("button.hamburger-button").click();
+    cy.get("div.sidebar").should("be.visible");
+    cy.get("#sensor-panel")
+      .should("exist")
+      .and("be.visible");
+  });
+  it("Should have scroll when overflowing", () => {
+    cy.mount(<HeaderComponent useSidebar={true} />);
+    cy.get("div.sidebar").should("not.be.visible");
+    cy.get("button.hamburger-button").click();
+    cy.get("div.sidebar").should("be.visible");
+
+    // Sufficiently large (well, excesssively in this test) viewport: no overflow
+    cy.viewport(600, 8000);
+    cy.get("div.sidebar")
+      .invoke("outerHeight")
+      .should("eq", 8000);
+    cy.get("div.sidebar")
+      .invoke("prop", "scrollHeight")
+      .should("eq", 8000);
+    cy.get("div.sidebar")
+      .invoke("outerHeight")
+      .should("eq", 8000);
+
+    // Tiny viewport: div should overflow
+    cy.viewport(600, 80);
+    cy.get("div.sidebar")
+      .invoke("outerHeight")
+      .should("eq", 80);
+    cy.get("div.sidebar")
+      .invoke("prop", "scrollHeight")
+      .should("be.greaterThan", 80);
+
+  })
 });
 
 export {};

--- a/norbit-webapp/tests/cypress/component/SensorConfigTests.cy.tsx
+++ b/norbit-webapp/tests/cypress/component/SensorConfigTests.cy.tsx
@@ -1,0 +1,64 @@
+import SensorConfigurationPanel from '@/sensorConfiguration/SensorConfigurationPanel';
+import React from 'react';
+import { store } from "@redux/store"
+import {sensorConfig, SensorConfig} from '@redux/slices/SensorConfig';
+
+describe('Header', () => {
+  beforeEach(() => {
+    cy.mount(<SensorConfigurationPanel />);
+  });
+
+  const validateStore = (conf: SensorConfig) => {
+    cy.wrap(store)
+      .invoke("getState")
+      .should("deep.contain", {
+        sensorConfig: conf,
+      });
+  };
+
+  it("Should render", () => {
+    cy.get("#sensor-panel")
+      .should("exist")
+      .and("be.visible");
+  });
+  it("Should affect redux", () => {
+    cy.get("#enable-accelerometer")
+      .scrollIntoView();
+    let state: SensorConfig = {
+      ...sensorConfig.getInitialState()
+    };
+    cy.log("State: ", state);
+    const ids: Array<[string, keyof SensorConfig]> = [
+      ["#enable-accelerometer", "accelerometer"],
+      ["#enable-temperature", "temperature"],
+      ["#enable-light", "light"],
+      ["#enable-sound", "sound"],
+    ];
+
+    validateStore(state);
+    for (const [id, sensor] of ids) {
+      // The inner loop ensure each checkbox is checked and unchecked. Full state management is
+      // handled by the integration tests, but as long as the true and false values are updated,
+      // any problems are not sourced from the config panel
+      for (let i = 0; i < 2; ++i) {
+        cy.get(id)
+          .scrollIntoView();
+        cy.get(id)
+          .click();
+        cy.log("State: ", state);
+        // This is stupid, but just
+        //     state[sensor] = !state[sensor]
+        // does nothing. Thanks, JavaScript!
+        state = {
+          ...state,
+          [sensor]: !state[sensor]
+        };
+        cy.log("State: ", state);
+        validateStore(state);
+      }
+    }
+
+  });
+});
+
+export {};

--- a/norbit-webapp/tests/cypress/integration/GraphStateTests.cy.tsx
+++ b/norbit-webapp/tests/cypress/integration/GraphStateTests.cy.tsx
@@ -1,5 +1,5 @@
 describe("Graph config", () => {
-  Cypress.config('defaultCommandTimeout', 10000);
+  //Cypress.config('defaultCommandTimeout', 10000);
   it("Should allow charts to be hidden", () => {
     cy.visit("/");
     let ids = [
@@ -8,6 +8,7 @@ describe("Graph config", () => {
       "enable-light",
       "enable-sound",
     ];
+    cy.get("#expand-sidebar").click();
 
     // Contains an array of arrays of bools corresponding to checkbox states.
     // This just generates an array of permutations of checkbox states, and 
@@ -28,6 +29,10 @@ describe("Graph config", () => {
       for (let i = 0; i < state.length; ++i) {
         let bool = state[i];
 
+        cy.get("#" + ids[i])
+          .scrollIntoView().wait(200);
+        cy.get("#" + ids[i])
+          .should("be.visible");
         if (bool) {
           ++active;
           cy.get("#" + ids[i]).check();


### PR DESCRIPTION
The primary change in this commit is moving the sensor  config into the sidebar from the dashboard. However, this change with react's useState would require using setState in a much more global state, which is annoying. Therefore, the SensorConfig struct has been moved into redux for global state management. 

Additionally, the temperature chart has now been disabled by default, as it still uses dummy data, and the app-sided implementation was a question mark last I checked. The decision can be revisited when we figure out what we do for the temperature implementation.

Closes #91 