### PR TITLE
Separate <data> intent filter from the launcher intent filter

### DIFF
--- a/norbit-mobileapp/flutter_application_1/android/app/src/main/AndroidManifest.xml
+++ b/norbit-mobileapp/flutter_application_1/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,8 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
This bug was introduced by 168d4c0cf4c84f9b79e766ee1acfd27831793b3a (thank you `git bisect`), and prevents the launcher icon from appearing. It also causes one of the bugs I attempted to fix in #103 by downgrading the target API to 32.

I'm still not sure why it only worked on some API 33 devices (such as @simeeid's phone), but I suspect it's down to how different phones handle malformed manifests. AOSP and near AOSP vendors (such as my phone, and the emulators) likely have stricter error checking than certain modified Android versions, such as that of Samsung.

I also don't understand why this didn't result in a compile error, but this might be hidden by Flutter. I'm pretty sure a malformed manifest would normally trigger a compile error, but arsed checking. Whatever the root cause behind  the error appearing to be obscure, it's now fixed, and the launcher icon is back on the screen. The workaround made as part of #103 is also redundant now, but can't revert it here as it hasn't been merged into main 