### PR TITLE
Draft: Expand the flutter CI build to the three latest versions of Android

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   build-android:
+    strategy:
+      fail-fast: false
+      matrix:
+        android_version: [32, 33, 34]
     # GitHub Actions doesn't have hardware acceleration in the ubuntu runner, because reasons
     runs-on: macos-latest
     steps:
@@ -44,7 +48,8 @@ jobs:
     - name: Run tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
-        api-level: 29
+        api-level: ${{matrix.android_version}}
+        target: google_apis
         profile: pixel_xl
         script: |
           flutter test -d test

--- a/norbit-mobileapp/flutter_application_1/android/app/src/main/AndroidManifest.xml
+++ b/norbit-mobileapp/flutter_application_1/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,8 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
This PR aims to expand the Android  builds of Flutter to a wider range of API versions, to ensure a situation like #104 is less likely to happen in the future. This is particularly important now that Android is getting increasingly strict about more or less everything, so ensuring compatibility with different versions is more complicated than it used to be.

Last time I tried this, I got errors about the emulator versions, so this might not lead anywhere; will undraft if I get it working.

Note that #104 needs to be merged first