### PR TITLE
Prevent unused JSON file from loading

### DIFF
--- a/norbit-mobileapp/flutter_application_1/lib/services/mqtt_service.dart
+++ b/norbit-mobileapp/flutter_application_1/lib/services/mqtt_service.dart
@@ -78,8 +78,8 @@ class MqttService {
   Future<bool> mqttConnect(String uniqueId) async {
     setStatus("Connecting MQTT Broker");
 
-  final awsCredentialsString = await File('assets/certificates/awsCredentials.json').readAsString();
-  final awsCredentials = jsonDecode(awsCredentialsString);
+  //final awsCredentialsString = await File('assets/certificates/awsCredentials.json').readAsString();
+  //final awsCredentials = jsonDecode(awsCredentialsString);
 
   fetchCognitoAuthSession();
 


### PR DESCRIPTION
#98 added a load of awsCredentials.json, a file that has not been internally shared. The result is also not used, so this PR comments it out, so it can be used and documented later (or fully removed in a later PR)