### PR TITLE
Set up automatic artefact deployment for Android

### DIFF
--- a/.github/workflows/artefact-deployment.yml
+++ b/.github/workflows/artefact-deployment.yml
@@ -1,0 +1,41 @@
+name: Artefact deployment
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  build-apk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "liberica"
+          java-version: "17.x"
+          cache: "gradle"
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Accept Android SDK licenses
+        run: |
+          yes | flutter doctor --android-licenses > /dev/null
+      - name: Install flutter deps
+        working-directory: norbit-mobileapp/flutter_application_1
+        run: |
+          flutter pub get
+      - name: Build APK
+        working-directory: norbit-mobileapp/flutter_application_1
+        run: |
+          flutter build apk
+          mv build/app/outputs/flutter-apk/app-release.apk ../../norbit-iot-simulator-${{ github.ref_name }}.apk
+      - name: Upload binaries to release
+        uses: softprops/action-gh-release@master
+        with:
+          files: norbit-iot-simulator-${{ github.ref_name }}.apk


### PR DESCRIPTION
As discussed at the meeting today, this PR sets up automatic apk builds. 

For ease-of-use, it's tied to GitHub releases and _not_ individual commits. The impact of this PR will there not be visible until after the fact, as it requires a release to run. To demonstrate its function, a separate repo was set up, and it does work there: https://github.com/OliviaWork/TDT4290Group1-CI-Scratchpad/releases/tag/v0.0.1-ci1

I have also verified that the app works with the dashboard, so it's a fully functional apk. The only caveat is that it's unsigned, so it results in an extra warning before install that isn't super obvious how you bypass. We can deal with that in the documentation.

Should just be a matter of merging and then making a release to test. It's not the most optimal way to test, but it's unfortunately the easiest way to test this in particular, as far as I know anyway.

This addresses part of #124 (but does not complete the issue entirely)